### PR TITLE
fix: make banner image responsive for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Website][website-shield]][website-url]
 
 <p align="center">
-  <img src="pair-programmer-logo.png" width="1200" height="372" alt="banner" />
+  <img src="pair-programmer-logo.png" style="max-width: 100%; height: auto;" alt="banner" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Removed hardcoded `width="1200" height="372"` from the banner `<img>` tag in `README.md`
- Replaced with `style="max-width: 100%; height: auto;"` so the image scales down on mobile screens while still filling full width on desktop

## Test plan

- [x] Verified on mobile (Chrome and Safari) — banner fits within screen width
- [x] Verified on desktop — banner renders at full content width